### PR TITLE
Ported PHP to Python webserver

### DIFF
--- a/getdata.py
+++ b/getdata.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# 
+# Get values from coin traking websites and add
+# to cache database
 import json
 import requests
 import _mysql
@@ -50,7 +53,7 @@ if success1 == True and success2 == True and success3 == True and success4 == Tr
         # Save ETH value now
         con.query("INSERT INTO eth (time, usd, eur) VALUES ("+str(now)+", "+str(eth_usd)+", "+str(eth_eur)+");")
 
-    except e:
+    except  e:
 
         print("Error %d: %s" % (e.args[0], e.args[1]))
         sys.exit(1)

--- a/getdata.py
+++ b/getdata.py
@@ -50,7 +50,7 @@ if success1 == True and success2 == True and success3 == True and success4 == Tr
         # Save ETH value now
         con.query("INSERT INTO eth (time, usd, eur) VALUES ("+str(now)+", "+str(eth_usd)+", "+str(eth_eur)+");")
 
-    except _mysql.Error, e:
+    except e:
 
         print("Error %d: %s" % (e.args[0], e.args[1]))
         sys.exit(1)

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <!-- Just for basic styling. -->
-    <link rel="stylesheet" href="main.css" />
+    <link rel="stylesheet" href="/assets/main.css" />
   </head>
   <body>
     <div id="contents">
@@ -110,6 +110,6 @@
     <!-- Charts -->
     <script src="https://npmcdn.com/recharts@0.22.0/umd/Recharts.min.js"></script>
     <!-- Main React Code -->
-    <script type="text/babel" src="main.js"></script>
+    <script type="text/babel" src="/assets/main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -36,7 +36,6 @@ $.ajax({
     url: "getdata/btc/"+change_btc,
     dataType: "JSON",
     success: function(json){
-      console.log(json);
         //here inside json variable you've the json returned by your PHP
         var btc = json.btc;
         var data = Object.keys(btc).map(function(e) {

--- a/main.js
+++ b/main.js
@@ -33,9 +33,10 @@ setInterval(function(){
 
 var allDataBTC = new Array();
 $.ajax({
-    url: "getdata.php?base=btc&change="+change_btc,
+    url: "getdata/btc/"+change_btc,
     dataType: "JSON",
     success: function(json){
+      console.log(json);
         //here inside json variable you've the json returned by your PHP
         var btc = json.btc;
         var data = Object.keys(btc).map(function(e) {
@@ -106,7 +107,7 @@ $.ajax({
 
 var allDataETH = new Array();
 $.ajax({
-    url: "getdata.php?base=eth&change="+change_eth,
+    url: "getdata/eth/"+change_eth,
     dataType: "JSON",
     success: function(json){
         //here inside json variable you've the json returned by your PHP

--- a/old_getdata.php
+++ b/old_getdata.php
@@ -1,4 +1,9 @@
 <?php
+// This is the old PHP file for
+// getting coin values from the database
+// and returning is as JSON. Replaced by function
+// in webserver.py
+
 #Show Error
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/webserver.py
+++ b/webserver.py
@@ -1,0 +1,60 @@
+import tornado.ioloop
+import tornado.web
+import MySQLdb
+import calendar, time
+import json
+
+class MainHandler(tornado.web.RequestHandler):
+
+	def get(self):
+		self.render("index.html")
+
+class ResourceHandler(tornado.web.RequestHandler):
+
+	def get(self, source):
+		resource = open(source).read()
+		self.set_header("Content-Type", 'text/css; charset="utf-8"')
+		self.write(resource)
+
+class DataHandler(tornado.web.RequestHandler):
+
+	def get(self, coin, change):
+		self.db = MySQLdb.connect('localhost', 'coingraphs', 'CGpassword', 'coingraphs')
+		c  = self.db.cursor()
+
+		if coin != "eth" and coin != "btc": # Quick dirty workaround for sanitization
+			self.write('{"message":"invalid_coin"}')
+		c.execute("SELECT time, %s AS price FROM "+coin+" WHERE time > %s ORDER BY time ASC",
+					   (change, calendar.timegm(time.gmtime()) - 36000))
+
+		row_headers=[x[0] for x in c.description]
+		data = c.fetchall()
+		print(data)
+		json_data = []
+		for row in data:
+			json_data.append(dict(zip(row_headers,row)))
+
+		self.write(json.dumps(json_data))
+
+
+def make_app():
+
+	settings = {
+		"debug": True
+	}
+
+	# Build our routes
+	return tornado.web.Application([
+		(r"/", MainHandler),
+		(r"/assets/(.*)", ResourceHandler),
+		(r"/getdata/(.*)/(.*)", DataHandler)
+	], **settings)
+
+def run_app():
+	app = make_app()
+	app.listen(8080)
+	print("Webserver listening on port 8080")
+
+	tornado.ioloop.IOLoop.current().start()
+
+run_app()

--- a/webserver.py
+++ b/webserver.py
@@ -4,11 +4,16 @@ import MySQLdb
 import calendar, time
 import json
 
+
+# Main handler, simply returns index.html
 class MainHandler(tornado.web.RequestHandler):
 
 	def get(self):
 		self.render("index.html")
 
+# Return "assets" aka javascript and css files. 
+# Uses Content-Type of CSS because CSS won't work
+# without it and JavaScript doesn't seem affected
 class ResourceHandler(tornado.web.RequestHandler):
 
 	def get(self, source):
@@ -16,12 +21,16 @@ class ResourceHandler(tornado.web.RequestHandler):
 		self.set_header("Content-Type", 'text/css; charset="utf-8"')
 		self.write(resource)
 
+# Fetch, parse and return data from database
 class DataHandler(tornado.web.RequestHandler):
 
 	def get(self, coin, change):
+		# Establish connection
 		self.db = MySQLdb.connect('localhost', 'coingraphs', 'CGpassword', 'coingraphs')
 		c  = self.db.cursor()
 		finish = True
+
+		# "Hacky" sanitization of inputs
 		if coin != "eth" and coin != "btc": # Quick dirty workaround for sanitization
 			self.write('{"message":"invalid_coin"}')
 			finish = False
@@ -30,6 +39,7 @@ class DataHandler(tornado.web.RequestHandler):
 			finish = False
 
 		if finish == True:
+			# Sanitization is fine, do query
 			q = "SELECT 'time', `%s` AS price FROM `%s` WHERE time > %%s ORDER BY time ASC" % (change, coin)
 			c.execute(q % (calendar.timegm(time.gmtime()) - 36000))
 
@@ -37,18 +47,20 @@ class DataHandler(tornado.web.RequestHandler):
 			data = c.fetchall()
 
 			json_data = []
-			for row in data:
+			for row in data: # Append rows to data array
 				json_data.append(dict(zip(row_headers,row)))
 
 			self.db.close()
 
-			self.write('{"'+coin+'":'+json.dumps(json_data)+"}")
+			# Weird little prefix/suffix because of how main.js
+			# already parses JSON from PHP
+			self.write('{"'+coin+'":'+json.dumps(json_data)+"}") 
 
 
 def make_app():
 
 	settings = {
-		"debug": True
+		"debug": True # Probably remove this in production, allows live code reloading
 	}
 
 	# Build our routes
@@ -60,7 +72,7 @@ def make_app():
 
 def run_app():
 	app = make_app()
-	app.listen(8080)
+	app.listen(8080) # Can run on port 80 but requires sudo on *nix
 	print("Webserver listening on port 8080")
 
 	tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
Ported over the functionality of PHP files to Python webserver file. Currently runs on port 8080 but could be changed to port 80 if so desired (requires running under root in Linux), recommend using nginx as a reverse proxy (as I have personally preferred to do). 

Can properly select and return values from database as JSON, with some unfortunately sort of hacky methods of sanitizing input (should be just fine however). 

Chose Tornado over Flask (or Django) for future websockets support, which could lessen server strain when scaling. Also is non-blocking, a huge plus. 