### PR TITLE
Add a configuration file

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,5 @@
+sql_host="127.0.0.1"
+sql_port=3306
+sql_user="coingraphs"
+sql_password="CGpassword"
+sql_database="coingraphs"

--- a/webserver.py
+++ b/webserver.py
@@ -68,6 +68,9 @@ class DataHandler(tornado.web.RequestHandler):
 def init_config():
 	define("config", default="conf.py", help="Path to config file",
        callback=lambda path: tornado.options.parse_config_file(path, final=False))
+
+	define("debug", default=False, type=bool, help="Enable debug mode")
+
 	define("sql_host", default="127.0.0.1", help="Hostname / IP of the SQL server")
 	define("sql_port", default=3306, type=int, help="Port where the SQL server is listening to")
 	define("sql_user", default="coingraphs", help="SQL server username")
@@ -76,13 +79,13 @@ def init_config():
 
 def make_app():
 
-	settings = {
-		"debug": True # Probably remove this in production, allows live code reloading
-	}
-
 	init_config()
 	tornado.options.parse_command_line()
 	tornado.options.parse_config_file(options.config)
+
+	settings = {
+		"debug": options.debug
+	}
 
 	# Build our routes
 	return tornado.web.Application([


### PR DESCRIPTION
This PR aims to let the user more easily change configuration options by loading directives from the command line and then from a file. I also disabled the debug mode by default—you can use `--debug` or define `debug` in the configuration file to enable it again.

I did not updated `get_data.py`, since I think it would be a good thing to merge it into `webserver.py` :-)