### PR TITLE
No need to execute same builds two times during PR (no final push)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -185,6 +185,7 @@ jobs:
 
     name: Build Daemon & Push to Docker Hub
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' # no need to exec same build two times during PR (no final push)
     permissions:
       contents: read
       packages: write
@@ -242,6 +243,7 @@ jobs:
 
     name: Build Client & Push to Docker Hub
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' # no need to exec same build two times during PR (no final push)
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
No need to execute same builds two times during PR (no final push).

So, if PR, execute a testing build for
- Deamon / github packages
- Client / github packages

But do not execute for
- Deamon / Docker Hub
- Client / Docker Hub
